### PR TITLE
Adds basic formatting similar to .NET

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,20 +74,28 @@ function normalize(string) {
   return stripped;
 }
 
-function stringify(buffer) {
+function stringify(buffer, delimiter) {
   return [
     buffer.toString('hex', 0, 4),
     buffer.toString('hex', 4, 6),
     buffer.toString('hex', 6, 8),
     buffer.toString('hex', 8, 10),
     buffer.toString('hex', 10, 16),
-  ].join('-');
+  ].join(delimiter);
 }
 
 function apply(mu) {
   // add to string method
-  mu.toString = function() {
-    return stringify(this.buffer);
+  // formatting parameter (optional) follows the behavior of Microsoft's UUID string function: https://docs.microsoft.com/en-us/dotnet/api/system.guid.tostring
+  mu.toString = function(format) {
+    let delimiter = '-';
+    let prefix = '';
+    let suffix = '';
+    if (format === 'N') delimiter = '';
+    if (format === 'B') { prefix = '{'; suffix = '}'; }
+    if (format === 'P') { prefix = '('; suffix = ')'; }
+
+    return prefix + stringify(this.buffer, delimiter) + suffix;
   }.bind(mu);
   return mu;
 }


### PR DESCRIPTION
My primary use case for this is an easy way to create the UUID string without dashes. However, I figured other formatting use cases were relevant as well. Microsoft has already thought through the most common use cases in .NET, so I copied the majority of their formatting argument options.