### PR TITLE
Exported type for mode

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -5,3 +5,4 @@ export type MUUID = Binary;
 export const v1: () => MUUID;
 export const v4: () => MUUID;
 export const from: (uuid: string | Binary) => MUUID;
+export const mode: (mode: 'canonical'| 'relaxed') => { v1, v4, from, mode};


### PR DESCRIPTION
`mode` function was not exported in type definitions, which resulted in `TS2305: Module "node_modules/uuid-mongodb/lib" has no exported member 'mode' while using typescript.