### PR TITLE
Implemented the specific types used in the mode function

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,8 +1,14 @@
 import { Binary } from "mongodb";
 
 export type MUUID = Binary;
+export type MODE = {
+  v1: () => MUUID,
+  v4: () => MUUID,
+  from: (uuid: string | Binary) => MUUID,
+  mode: MODE
+}
 
 export const v1: () => MUUID;
 export const v4: () => MUUID;
 export const from: (uuid: string | Binary) => MUUID;
-export const mode: (mode: 'canonical'| 'relaxed') => { v1, v4, from, mode};
+export const mode: (mode: 'canonical'| 'relaxed') => MODE;


### PR DESCRIPTION
The current declaration of the mode function in lib/index.d.ts is causing downstream typescript projects to require the "noImplicitAny" flag to be set to false in the compiler options.  This is not desirable for some/most projects, so this PR implements specific types for the function declaration.