### PR TITLE
updated typescript definition to include formatted toString

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,6 +1,17 @@
 import { Binary } from "mongodb";
 
-export type MUUID = Binary;
+export type UUIDFormat = 'N' | 'D' | 'B' | 'P';
+export interface MUUID extends Binary {
+  /**
+   * Converts the uuid into its canonical representation.
+   * @param format The type of canonical representation.
+   *  "N" for 32 digits, e.g. 00000000000000000000000000000000;
+   *  "D" for 32 digits separated by hyphens (default), e.g. 00000000-0000-0000-0000-000000000000;
+   *  "B" for 32 digits separated by hyphens, enclosed in braces, e.g. {00000000-0000-0000-0000-000000000000}; or
+   *  "P" for 32 digits separated by hyphens, enclosed in parentheses, e.g. (00000000-0000-0000-0000-000000000000)
+   */
+  toString(format?: UUIDFormat): string;
+}
 export type Mode = {
   v1: () => MUUID,
   v4: () => MUUID,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uuid-mongodb",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "description": "Generates and parses MongoDB BSON UUIDs. Plays nicely with others including the MongoDB native driver and Mongoose.",
   "main": "lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
This enables TypeScript users to use the formatted toString method, along with offering better IntelliSense.

![image](https://user-images.githubusercontent.com/441347/107640117-ccd23600-6c3f-11eb-9e42-6d41a0346118.png)
