### PR TITLE
Add support for mongodb 3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "mongodb": "3.6.x || 4.0.x || 4.1.x || 4.2.x"
+    "mongodb": "3.6.x || 3.7.x || 4.0.x || 4.1.x || 4.2.x"
   },
   "devDependencies": {
     "eslint": "^8.5.0",


### PR DESCRIPTION
Similar to #63, please add the new version of mongodb 3.7 nodejs driver. 