### PR TITLE
Upgraded to support MongoDB both v4 and v5 drivers

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -10,7 +10,7 @@ export interface MUUID extends Binary {
    *  "B" for 32 digits separated by hyphens, enclosed in braces, e.g. {00000000-0000-0000-0000-000000000000}; or
    *  "P" for 32 digits separated by hyphens, enclosed in parentheses, e.g. (00000000-0000-0000-0000-000000000000)
    */
-  toString(format?: "utf8" | "utf-8" | "base64" | "hex"): string;
+  toString(format?: 'utf8' | 'utf-8' | 'base64' | 'hex'): string;
   toString(format?: UUIDFormat): string;
 }
 export type Mode = {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -10,6 +10,7 @@ export interface MUUID extends Binary {
    *  "B" for 32 digits separated by hyphens, enclosed in braces, e.g. {00000000-0000-0000-0000-000000000000}; or
    *  "P" for 32 digits separated by hyphens, enclosed in parentheses, e.g. (00000000-0000-0000-0000-000000000000)
    */
+  toString(format?: "utf8" | "utf-8" | "base64" | "hex"): string;
   toString(format?: UUIDFormat): string;
 }
 export type Mode = {

--- a/package.json
+++ b/package.json
@@ -27,14 +27,14 @@
     "uuid": "^9.0.0"
   },
   "peerDependencies": {
-    "mongodb": "3.6.x || 3.7.x || 4.x"
+    "mongodb": "3.6.x || 3.7.x || 4.x || 5.x"
   },
   "devDependencies": {
-    "eslint": "8.30.0",
-    "eslint-config-prettier": "^8.5.0",
+    "eslint": "8.38.0",
+    "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^4.2.1",
     "mocha": "^10.2.0",
-    "prettier": "^2.8.1",
-    "mongodb": "4.13.0"
+    "prettier": "^2.8.7",
+    "mongodb": "5.2.0"
   }
 }

--- a/test/uuid-mongodb_spec.js
+++ b/test/uuid-mongodb_spec.js
@@ -55,7 +55,7 @@ describe('MUUID', function () {
 
     it('should convert uuid from mongo BSON binary', () => {
       const mUUID = MUUID.from(
-        Binary(uuidv1(null, Buffer.alloc(16)), Binary.SUBTYPE_UUID)
+        new Binary(uuidv1(null, Buffer.alloc(16)), Binary.SUBTYPE_UUID)
       );
       assert.equal(mUUID instanceof Binary, true);
       assert.equal(validate(mUUID.toString()), true);


### PR DESCRIPTION
Tested with both the v4 and the v5 driver in the Cloudize API Games Framework. All downstream tests pass, so this looks good.